### PR TITLE
fix：bottomIsVisibleObserverEl 应该在 new Scroller前appendChild, 

### DIFF
--- a/src/lib/directive.js
+++ b/src/lib/directive.js
@@ -362,9 +362,9 @@ export const directiveVue3 = {
       return
     }
     const bottomIsVisibleObserverEl = document.createElement('div')
-    const scroller = new Scroller(tableBodyWrapper, bottomIsVisibleObserverEl, value)
-
     el.appendChild(bottomIsVisibleObserverEl)
+
+    const scroller = new Scroller(tableBodyWrapper, bottomIsVisibleObserverEl, value)
     el.appendChild(scroller.dom)
     el.horizontalScroll = scroller
 


### PR DESCRIPTION
fix：bottomIsVisibleObserverEl 应该在 new Scroller前appendChild, 因为 new Scrolle 中有bottomIsVisibleObserverEl的监听
`
 this.bottomIsVisibleObserver = new IntersectionObserver(([entry]) => {
    this.bottomIsVisible = entry.intersectionRatio > 0
    this.checkIsScrollBottom()
  })
  this.bottomIsVisibleObserver.observe(this.bottomIsVisibleObserverEl)
`